### PR TITLE
Powerset generator in python

### DIFF
--- a/python/algorithms/combinatorics/powersets/powerset.py
+++ b/python/algorithms/combinatorics/powersets/powerset.py
@@ -42,19 +42,20 @@ def generate_power_set(a, n):
 		generate_power_set_helper (powerset, subsets_selector[i:], [], 0, n-i)
 
 	# Fill in actual items from the original set based on the subset masks
-	for i in range(n+1):
-		for x in powerset[i]:
+	for i in range(1, n+1):
+		for j in range(len(powerset[i])):
+			# row 'i' has 'i' items in each subset
 			for k in range(i):
-				x[k] = a[x[k]]
+				powerset[i][j][k] = a[powerset[i][j][k]]
 
-	# If the original set was a string, stringify the subsets too
+			# If the original set was a string, stringify the subsets too
+			if isinstance(a, str):
+				powerset[i][j] = ''.join(powerset[i][j])
+
+	# If the original set was a string, stringify the empty subset
+	# into empty string ""
 	if isinstance(a, str):
-		powerset_str = [[] for i in xrange(n+1)]
-		powerset_str[0] = ""
-		for i in range(1,n+1):
-			for x in powerset[i]:
-				powerset_str[i].append(''.join(x))
-		return powerset_str
+		powerset[0] = ""
 
 	return powerset
 

--- a/python/algorithms/combinatorics/powersets/powerset.py
+++ b/python/algorithms/combinatorics/powersets/powerset.py
@@ -37,8 +37,24 @@ def generate_power_set(a, n):
 	# Initialize an empty 2D list to store subsets ordered by length
 	# Lengths of subsets vary from 0 to n
 	powerset = [[] for i in xrange(n+1)]
+	subsets_selector = range(n)
 	for i in xrange(n):
-		generate_power_set_helper (powerset, a[i:], [], 0, n-i)
+		generate_power_set_helper (powerset, subsets_selector[i:], [], 0, n-i)
+
+	# Fill in actual items from the original set based on the subset masks
+	for i in range(n+1):
+		for x in powerset[i]:
+			for k in range(i):
+				x[k] = a[x[k]]
+
+	# If the original set was a string, stringify the subsets too
+	if isinstance(a, str):
+		powerset_str = [[] for i in xrange(n+1)]
+		powerset_str[0] = ""
+		for i in range(1,n+1):
+			for x in powerset[i]:
+				powerset_str[i].append(''.join(x))
+		return powerset_str
 
 	return powerset
 
@@ -91,14 +107,13 @@ def basic_testcases():
 	assert subsets[5] == []
 
 
-	a = range(1, 6)
-	powerset = generate_power_set(a, len(a))
-	assert(powerset == [[],
-		[[1], [2], [3], [4], [5]],
-		[[1, 2], [1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5], [3, 4], [3, 5], [4, 5]],
-		[[1, 2, 3], [1, 2, 4], [1, 2, 5], [1, 3, 4], [1, 3, 5], [1, 4, 5], [2, 3, 4], [2, 3, 5], [2, 4, 5], [3, 4, 5]],
-		[[1, 2, 3, 4], [1, 2, 3, 5], [1, 2, 4, 5], [1, 3, 4, 5], [2, 3, 4, 5]],
-		[[1, 2, 3, 4, 5]]])
+	a = "abcde"
+	assert(generate_power_set(a, len(a)) == ['', ['a', 'b', 'c', 'd', 'e'], ['ab', 'ac', 'ad', 'ae', 'bc', 'bd', 'be', 'cd', 'ce', 'de'], ['abc', 'abd', 'abe', 'acd', 'ace', 'ade', 'bcd', 'bce', 'bde', 'cde'], ['abcd', 'abce', 'abde', 'acde', 'bcde'], ['abcde']])
+
+	assert generate_power_set("abc", 3) == ['', ['a', 'b', 'c'], ['ab', 'ac', 'bc'], ['abc']]
+	assert generate_power_set(('a', 'b', 'c'), 3) == [[], [['a'], ['b'], ['c']], [['a', 'b'], ['a', 'c'], ['b', 'c']], [['a', 'b', 'c']]]
+
+	assert generate_power_set([1,3,5,7], 4) == [[], [[1], [3], [5], [7]], [[1, 3], [1, 5], [1, 7], [3, 5], [3, 7], [5, 7]], [[1, 3, 5], [1, 3, 7], [1, 5, 7], [3, 5, 7]], [[1, 3, 5, 7]]]
 
 
 if __name__ == "__main__":

--- a/python/algorithms/combinatorics/powersets/powerset.py
+++ b/python/algorithms/combinatorics/powersets/powerset.py
@@ -3,48 +3,105 @@
 # Add the current subset to the powerset list ordered by size
 def add_to_powerset(powerset, prefix):
 	i = len(prefix)
-
 	if prefix not in powerset[i]:
 		powerset[i].append(prefix)
 
+
 # Generate subsets starting with given prefix
+# Generate all subsets that start at 'startindex' of lengths 1,2,..(n-startindex), and append them to 'prefix'
+# e.g., generate_power_set_helper(_, [1..5], [], 0, 2)
+# subsets:
+#  => len 1: [1]
+#  => len 2: [1,2]
+#
+# e.g., generate_power_set_helper(_, [1..5], [x], 0, 3)
+# subsets:
+#  => len 2: [x,1]
+#  => len 3: [x,1,2], [x,1,3]
+#  => len 4: [x,1,2,3]
 def generate_power_set_helper(powerset, a, prefix, startindex, n):
-	if (startindex >= n):
+	if (startindex == n):
 		return 
 
 	prefix.append(a[startindex])
 	add_to_powerset(powerset, prefix[:])
 
-	if len(prefix) == n:
-		return 
-
-	generate_power_set_helper(powerset, a, prefix[:], startindex+1, n)
-	add_to_powerset(powerset, prefix[:])
-
-	for i in range(startindex+2, n):
+	for i in range(startindex+1, n):
 		generate_power_set_helper(powerset, a, prefix[:], i, n)
 		add_to_powerset(powerset, prefix[:])
 
-# Lose the starting elements of the set, one at a time to generate subsets starting from 2,3,... etc.
-def generate_power_set(powerset, a, n):
-	for i in range(n, 0, -1):
-		generate_power_set_helper (powerset, a, [], 0, i) 
-		a.pop(0)
 
-def main():
-	n = int(raw_input())
-	a = range(1, n+1)
 
+# Generate all subsets starting from a[0], a[1] .. a[n-1] and merge all of them into a list
+def generate_power_set(a, n):
 	# Initialize an empty 2D list to store subsets ordered by length
-	powerset = []
-	for i in range(0, n+1):
-		powerset.append([])
+	# Lengths of subsets vary from 0 to n
+	powerset = [[] for i in xrange(n+1)]
+	for i in xrange(n):
+		generate_power_set_helper (powerset, a[i:], [], 0, n-i)
 
-	generate_power_set(powerset, a, n)
+	return powerset
 
-	for i in range(0, n+1):
-		print powerset[i]
+
+
+
+def basic_testcases():
+	a = range(1, 6)
+	subsets = [[] for _ in xrange(5)]
+	generate_power_set_helper(subsets, a, [], 0, 1)
+	assert(subsets == [[], [[1]], [], [], []])
+
+	subsets = [[] for _ in xrange(5)]
+	generate_power_set_helper(subsets, a, [], 1, 2)
+	assert(subsets == [[], [[2]], [], [], []])
+
+	subsets = [[] for _ in xrange(5)]
+	generate_power_set_helper(subsets, a, [], 0, 2)
+	assert(subsets == [[], [[1]], [[1,2]], [], []])
+
+	subsets = [[] for _ in xrange(5)]
+	generate_power_set_helper(subsets, a, [], 1, 3)
+	assert(subsets == [[], [[2]], [[2, 3]], [], []])
+
+	subsets = [[] for _ in xrange(5)]
+	generate_power_set_helper(subsets, a, [], 0, 3)
+	assert(subsets == [[], [[1]], [[1,2], [1, 3]], [[1,2,3]], []])
+
+	subsets = [[] for _ in xrange(5)]
+	generate_power_set_helper(subsets, a, ['x'], 0, 3)
+	assert(subsets == [[], [], [['x', 1]], [['x',1,2], ['x',1, 3]], [['x',1,2,3]]])
+
+	subsets = [[] for _ in xrange(6)]
+	generate_power_set_helper(subsets, a, [], 0, 5)
+	assert subsets[0] == []
+	assert subsets[1] == [[1]]
+	assert subsets[2] == [[1,2], [1,3], [1,4], [1,5]]
+	assert subsets[3] == [[1,2,3], [1,2,4], [1,2,5], [1,3,4], [1,3,5], [1,4,5]]
+	assert subsets[4] == [[1,2,3,4], [1,2,3,5], [1,2,4,5], [1,3,4,5]]
+	assert subsets[5] == [[1,2,3,4,5]]
+
+	subsets = [[] for _ in xrange(6)]
+	generate_power_set_helper(subsets, a, [], 1, 5)
+	[[], [[2]], [[2, 3], [2, 4], [2, 5]], [[2, 3, 4], [2, 3, 5], [2, 4, 5]], [[2, 3, 4, 5]], []]
+	assert subsets[0] == []
+	assert subsets[1] == [[2]]
+	assert subsets[2] == [[2,3], [2,4], [2,5]]
+	assert subsets[3] == [[2,3,4], [2,3,5], [2,4,5]]
+	assert subsets[4] == [[2,3,4,5]]
+	assert subsets[5] == []
+
+
+	a = range(1, 6)
+	powerset = generate_power_set(a, len(a))
+	assert(powerset == [[],
+		[[1], [2], [3], [4], [5]],
+		[[1, 2], [1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5], [3, 4], [3, 5], [4, 5]],
+		[[1, 2, 3], [1, 2, 4], [1, 2, 5], [1, 3, 4], [1, 3, 5], [1, 4, 5], [2, 3, 4], [2, 3, 5], [2, 4, 5], [3, 4, 5]],
+		[[1, 2, 3, 4], [1, 2, 3, 5], [1, 2, 4, 5], [1, 3, 4, 5], [2, 3, 4, 5]],
+		[[1, 2, 3, 4, 5]]])
+
 
 if __name__ == "__main__":
-	main()
+	basic_testcases()
+
 

--- a/python/algorithms/combinatorics/powersets/powerset2.py
+++ b/python/algorithms/combinatorics/powersets/powerset2.py
@@ -1,0 +1,83 @@
+'''
+Generate all subsets of a set, a powerset
+
+Use set bits in the binary representation of a number to create a powerset.
+e.g., 5
+Use 0 -> 5, 2**5 == 32
+Use bits set in 0, 1, 2, ... 31 as anchors to picking items from the set into a subset.
+
+set: {a,b,c}
+n: 3
+bits-table of 0 to 7 (2**3-1)
+
+i  | bits  | subset
+---|-------|-------
+1. | 0 0 0 |  {}
+2. | 0 0 1 |  {c}
+3. | 0 1 0 |  {b}
+4. | 0 1 1 |  {b,c}
+5. | 1 0 0 |  {a}
+6. | 1 0 1 |  {a.c}
+7. | 1 1 0 |  {a,b}
+8. | 1 1 1 |  {a,b,c}
+'''
+
+
+# Add 1 to a binary set containing bits
+# Adding 1 in binary => flip all 1s from the right until a 0 is found
+# flip the 1 to 0, and the resulting bit-sequence is the result of adding 1
+# to the binary sequence
+# e.g.
+# 111011 (+1) -> 111 011, flip last two 1s and the zero
+#   = 111 100
+def add_binary(bin_set, n):
+	for i in range(n-1, -1, -1):
+		bin_set[i] = 0 if bin_set[i] else 1
+
+		if bin_set[i] == 1:
+			return bin_set
+
+	return bin_set
+
+
+
+# Generate a list containing binary representations of 1..2**n
+# to be used as a mask for filling in subsets
+def generate_powerset_masks(n):
+	binary_masks = []
+	bin_mask = [0]*n
+	for i in range(1<<n):
+		binary_masks.append(bin_mask[:])
+		bin_mask = add_binary(bin_mask, n)
+
+	return binary_masks
+
+
+
+def generate_powerset(a, n):
+	powerset = []
+	for bin_mask in generate_powerset_masks(n):
+		subset = []
+		for i in range(n):
+			if bin_mask[i]:
+				subset.append(a[i])
+
+		# if the original set was a string, stringify the subset too
+		if isinstance(a, str):
+			subset = ''.join(subset)
+		powerset.append(subset)
+
+	return powerset
+
+
+def basic_testcases():
+	a = [1,3,5,7]
+	assert generate_powerset(a, 4) == [[], [7], [5], [5, 7], [3], [3, 7], [3, 5], [3, 5, 7], [1], [1, 7], [1, 5], [1, 5, 7], [1, 3], [1, 3, 7], [1, 3, 5], [1, 3, 5, 7]]
+
+	assert generate_powerset("abc", 3) == ['', 'c', 'b', 'bc', 'a', 'ac', 'ab', 'abc']
+	assert generate_powerset("abcde", 5) == ['', 'e', 'd', 'de', 'c', 'ce', 'cd', 'cde', 'b', 'be', 'bd', 'bde', 'bc', 'bce', 'bcd', 'bcde', 'a', 'ae', 'ad', 'ade', 'ac', 'ace', 'acd', 'acde', 'ab', 'abe', 'abd', 'abde', 'abc', 'abce', 'abcd', 'abcde']
+	
+
+if __name__ == '__main__':
+	basic_testcases()
+


### PR DESCRIPTION
Two power set generation algorithms implemented in python.
1. Generate all subsets of length [1..n] that start with a[i], and merge them into a power set ordered by subset lengths.
2. Use bits set in binary representations of 1..2ⁿ as masks to select items from the original set into individual subsets that make up the power set.